### PR TITLE
Fix FML not finding mod when run dir is outside project dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,7 +404,7 @@ runClient {
 
     if (usesMixins.toBoolean()) {
         arguments += [
-                "--mods=../build/libs/$archivesBaseName-${version}.jar"
+                "--mods=" + Paths.get("$projectDir").resolve(minecraft.runDir).normalize().relativize(Paths.get("$projectDir/build/libs/$archivesBaseName-${version}.jar"))
         ]
     }
 
@@ -434,7 +434,7 @@ runServer {
 
     if (usesMixins.toBoolean()) {
         arguments += [
-                "--mods=../build/libs/$archivesBaseName-${version}.jar"
+                "--mods=" + Paths.get("$projectDir").resolve(minecraft.runDir).normalize().relativize(Paths.get("$projectDir/build/libs/$archivesBaseName-${version}.jar"))
         ]
     }
 


### PR DESCRIPTION
The mod path used in FML's command line argument is hardcoded in a way that makes it only work if the run directory is a direct child of the project directory. This PR makes it so all of the following run directory configurations work (tested on Windows and Linux):
* `run` (only this one worked previously)
* `runParent/run` (subdirectory of project directory)
* `../run` (directory outside project directory)