### PR TITLE
Assemble artifacts explicitly before publish

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Setup the workspace
         run: ./gradlew setupCIWorkspace
 
+      - name: Assemble the artifacts
+        run: ./gradlew assemble
+
       - name: Publish to Maven, Modrinth, and CurseForge
         run: ./gradlew publish
         env:


### PR DESCRIPTION
Hi!
I made those changes because I have issue with current CI process. Without assemble stage there is no artifacts built and release stage says it unable to find artifacts.
![image](https://user-images.githubusercontent.com/68472958/227075596-f113d99c-8d9f-4f8c-9a94-58c09c69b5f9.png)
